### PR TITLE
For Windows libcliv2.dll is named wincli32.dll

### DIFF
--- a/src/teradata_common.cpp
+++ b/src/teradata_common.cpp
@@ -35,12 +35,12 @@ static const char *const CLIV2_SEARCH_PATHS[] = {
     "/Library/Application Support/teradata/client/16.20/lib/libcliv2.dylib",
 #endif
 #if defined(_WIN32)
-    "libcliv2.dll",
-    "C:\\Program Files\\Teradata\\Client\\20.00\\bin\\libcliv2.dll",
-    "C:\\Program Files\\Teradata\\Client\\17.20\\bin\\libcliv2.dll",
-    "C:\\Program Files\\Teradata\\Client\\17.10\\bin\\libcliv2.dll",
-    "C:\\Program Files\\Teradata\\Client\\17.00\\bin\\libcliv2.dll",
-    "C:\\Program Files\\Teradata\\Client\\16.20\\bin\\libcliv2.dll",
+    "wincli32.dll",
+    "C:\\Program Files\\Teradata\\Client\\20.00\\bin\\wincli32.dll",
+    "C:\\Program Files\\Teradata\\Client\\17.20\\bin\\wincli32.dll",
+    "C:\\Program Files\\Teradata\\Client\\17.10\\bin\\wincli32.dll",
+    "C:\\Program Files\\Teradata\\Client\\17.00\\bin\\wincli32.dll",
+    "C:\\Program Files\\Teradata\\Client\\16.20\\bin\\wincli32.dll",
 #endif
 #if defined(__linux__)
     "libcliv2.so",


### PR DESCRIPTION
It works when copying wincli32.dll and renaming to libcliv2.dll

>wincli32.dll
This is the equivalent to the UNIX library libcliv2. Both 32-bit and 64-bit versions of this dll exist.


https://docs.teradata.com/r/Enterprise_IntelliFlex_Lake_VMware/Teradata-Call-Level-Interface-Version-2-Reference-for-Workstation-Attached-Systems-20.00/CLI-Files-and-Setup/Finding-CLI-Files-on-the-System/Required-Files-for-Windows-Platforms